### PR TITLE
refactor: rewrited fp-compose.js to TypeScript

### DIFF
--- a/JavaScript/fp-compose.ts
+++ b/JavaScript/fp-compose.ts
@@ -1,0 +1,37 @@
+interface Point {
+    x: number;
+    y: number;
+}
+
+interface PointFunctor extends Point {
+    map: <T>(fn: (point: Point) => T) => T;
+}
+
+const createPointFunctor = ({ x, y }: Point): PointFunctor => ({
+    x, 
+    y,
+    map: <T>(fn: (point: Point) => T): T => fn({ x, y })
+});
+
+const move = (delta: Point) => ({ x, y }: Point) =>
+    createPointFunctor({
+        x: x + delta.x,
+        y: y + delta.y
+    });
+
+const clone = ({ x, y }: Point): PointFunctor => createPointFunctor({ x, y });
+
+const pointToString = ({ x, y }: Point): string => `(${x}, ${y})`;
+
+const pipe = (...fns: Array<(arg: Point) => Point>) => (arg: Point): Point =>
+    fns.reduce((acc, fn) => fn(acc), arg);
+
+const p1 = createPointFunctor({x: 10, y: 20});
+console.log(p1.map(pointToString));
+
+const operations = pipe(clone, move({ x: -5, y: 10 }));
+console.log(pointToString(p1.map(operations)));
+
+
+// move do not working
+// to string is not acceptanble here 


### PR DESCRIPTION
- created Point interface to describe passing data
- created PointFunctor derived interface
- added types to functions
- unified param type from curried parameter style to destructured object

## main changes

### fixed pipe flow issue
- in fp-compose.js move function returned functor object without x and y fields. That is why pipe example flow works uncorrect and toString result was {undefined, undefined}
- solution: PointFunctor interface extends Point, ensuring data is accessible through the chain

### improved function composition strategy
- functions in pipe should maintain chainable types, toString breaks the chain by returning string, making further operations impossible
- solution: moved pointToString outside of pipe for cleaner separation of concerns